### PR TITLE
Get rid of linker errors and implement h_malloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,3 @@ gcc = []
 light = []
 # "standard" feature is "default.mk" config in hardened_malloc
 standard = []
-
-[dependencies]
-libc = "0.2"
-
-[build-dependencies]
-cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -68,11 +68,6 @@ fn main() {
         update_submodules();
     }
 
-    println!(
-        "cargo:include={}/src/hardened_malloc/include",
-        current_working_directory.display()
-    );
-
     let compiler = if cfg!(feature = "gcc") {
         check_compiler("gcc");
         "gcc"
@@ -118,15 +113,15 @@ fn main() {
     }
 
     let ar_lib_output = if cfg!(feature = "light") {
-        "/libhardened_malloc-light.a"
+        out_dir.clone() + "/libhardened_malloc-light.a"
     } else {
-        "/libhardened_malloc.a"
+        out_dir.clone() + "/libhardened_malloc.a"
     };
 
     // TOOD: improve this
     let ar_args = [
-        "r".to_owned(),
-        out_dir.clone() + ar_lib_output,
+        "rcs".to_owned(),
+        ar_lib_output,
         out_dir.clone() + "/chacha.o",
         out_dir.clone() + "/h_malloc.o",
         out_dir.clone() + "/memory.o",
@@ -141,7 +136,6 @@ fn main() {
     println!("running {:?} with args {:?}", ar_command, ar_args);
 
     let ar_output = ar_command
-        .current_dir("src/hardened_malloc/")
         .args(ar_args)
         .output()
         .unwrap_or_else(|error| {
@@ -165,10 +159,10 @@ fn main() {
     println!("[hardened_malloc-sys]: OUT_DIR={}", out_dir);
 
     if cfg!(feature = "light") {
-        println!("cargo:rustc-link-lib=hardened_malloc-light");
+        println!("cargo:rustc-link-lib=static=hardened_malloc-light");
         println!("cargo:rustc-link-search={}", out_dir);
     } else {
-        println!("cargo:rustc-link-lib=hardened_malloc");
+        println!("cargo:rustc-link-lib=static=hardened_malloc");
         println!("cargo:rustc-link-search={}", out_dir);
     }
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,0 +1,77 @@
+#![no_std]
+
+use core::ffi::{c_int, c_void};
+
+extern crate libc;
+
+extern "C" {
+    /*
+        TODO: implement this
+
+        #ifdef __ANDROID__
+    #define H_MALLOC_USABLE_SIZE_CONST const
+    #else
+    #define H_MALLOC_USABLE_SIZE_CONST
+    #endif
+
+        for:
+        // glibc extensions
+    size_t h_malloc_usable_size(H_MALLOC_USABLE_SIZE_CONST void *ptr);
+     */
+
+    /* C standard */
+
+    pub fn h_malloc(size: usize) -> *mut c_void;
+    pub fn h_calloc(nmemb: usize, size: usize) -> *mut c_void;
+    pub fn h_realloc(ptr: *mut c_void, size: usize) -> *mut c_void;
+    pub fn h_aligned_malloc(alignment: usize, size: usize) -> *mut c_void;
+    pub fn h_free(ptr: *mut c_void);
+
+    /* POSIX */
+
+    pub fn h_posix_memalign(memptr: *mut *mut c_void, alignment: usize, size: usize) -> c_int;
+
+    /* glibc extensions */
+
+    pub fn h_malloc_usable_size(ptr: *const c_void) -> usize;
+    pub fn h_mallopt(param: c_int, value: c_int) -> c_int;
+    pub fn h_malloc_trim(pad: usize) -> c_int;
+    pub fn h_malloc_stats(void: c_void) -> c_void;
+
+    /* obsolete glibc extensions */
+
+    pub fn h_memalign(alignment: usize, size: usize) -> *mut c_void;
+    pub fn h_pvalloc(size: usize) -> *mut c_void;
+    pub fn h_cfree(ptr: *mut c_void) -> c_void;
+    pub fn h_malloc_get_state(void: c_void) -> c_void;
+    pub fn h_malloc_set_state(ptr: *mut c_void) -> c_int;
+
+    /*TODO: implement this see the top:
+        #if defined(__GLIBC__) || defined(__ANDROID__)
+    struct mallinfo h_mallinfo(void);
+    #endif
+    #ifndef __ANDROID__
+    int h_malloc_info(int options, FILE *fp);
+    #endif
+     */
+
+    /* hardened_malloc extensions */
+
+    /// return an upper bound on object size for any pointer based on malloc metadata
+    pub fn h_malloc_object_size(ptr: *const c_void) -> usize;
+
+    /// similar to malloc_object_size, but avoids locking so the results are much more limited
+    pub fn h_malloc_object_size_fast(ptr: *const c_void) -> usize;
+
+    /// The free function with an extra parameter for passing the size requested at
+    /// allocation time.
+    ///
+    /// This offers the same functionality as C++14 sized deallocation and can be
+    /// used to implement it.
+    ///
+    /// A performance-oriented allocator would use this as a performance
+    /// enhancement with undefined behavior on a mismatch. Instead, this hardened
+    /// allocator implementation uses it to improve security by checking that the
+    /// passed size matches the allocated size.
+    pub fn h_free_sized(ptr: *mut c_void, expected_size: usize) -> c_void;
+}

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,9 +1,6 @@
-#![no_std]
-
 use core::ffi::{c_int, c_void};
 
-extern crate libc;
-
+#[allow(dead_code)]
 extern "C" {
     /*
         TODO: implement this
@@ -21,30 +18,30 @@ extern "C" {
 
     /* C standard */
 
-    pub fn h_malloc(size: usize) -> *mut c_void;
-    pub fn h_calloc(nmemb: usize, size: usize) -> *mut c_void;
-    pub fn h_realloc(ptr: *mut c_void, size: usize) -> *mut c_void;
-    pub fn h_aligned_malloc(alignment: usize, size: usize) -> *mut c_void;
-    pub fn h_free(ptr: *mut c_void);
+    pub fn malloc(size: usize) -> *mut c_void;
+    pub fn calloc(nmemb: usize, size: usize) -> *mut c_void;
+    pub fn realloc(ptr: *mut c_void, size: usize) -> *mut c_void;
+    pub fn aligned_malloc(alignment: usize, size: usize) -> *mut c_void;
+    pub fn free(ptr: *mut c_void);
 
     /* POSIX */
 
-    pub fn h_posix_memalign(memptr: *mut *mut c_void, alignment: usize, size: usize) -> c_int;
+    pub fn posix_memalign(memptr: *mut *mut c_void, alignment: usize, size: usize) -> c_int;
 
     /* glibc extensions */
 
-    pub fn h_malloc_usable_size(ptr: *const c_void) -> usize;
-    pub fn h_mallopt(param: c_int, value: c_int) -> c_int;
-    pub fn h_malloc_trim(pad: usize) -> c_int;
-    pub fn h_malloc_stats(void: c_void) -> c_void;
+    pub fn malloc_usable_size(ptr: *const c_void) -> usize;
+    pub fn mallopt(param: c_int, value: c_int) -> c_int;
+    pub fn malloc_trim(pad: usize) -> c_int;
+    pub fn malloc_stats(void: c_void) -> c_void;
 
     /* obsolete glibc extensions */
 
-    pub fn h_memalign(alignment: usize, size: usize) -> *mut c_void;
-    pub fn h_pvalloc(size: usize) -> *mut c_void;
-    pub fn h_cfree(ptr: *mut c_void) -> c_void;
-    pub fn h_malloc_get_state(void: c_void) -> c_void;
-    pub fn h_malloc_set_state(ptr: *mut c_void) -> c_int;
+    pub fn memalign(alignment: usize, size: usize) -> *mut c_void;
+    pub fn pvalloc(size: usize) -> *mut c_void;
+    pub fn cfree(ptr: *mut c_void) -> c_void;
+    pub fn malloc_get_state(void: c_void) -> c_void;
+    pub fn malloc_set_state(ptr: *mut c_void) -> c_int;
 
     /*TODO: implement this see the top:
         #if defined(__GLIBC__) || defined(__ANDROID__)
@@ -58,10 +55,10 @@ extern "C" {
     /* hardened_malloc extensions */
 
     /// return an upper bound on object size for any pointer based on malloc metadata
-    pub fn h_malloc_object_size(ptr: *const c_void) -> usize;
+    pub fn malloc_object_size(ptr: *const c_void) -> usize;
 
     /// similar to malloc_object_size, but avoids locking so the results are much more limited
-    pub fn h_malloc_object_size_fast(ptr: *const c_void) -> usize;
+    pub fn malloc_object_size_fast(ptr: *const c_void) -> usize;
 
     /// The free function with an extra parameter for passing the size requested at
     /// allocation time.
@@ -73,5 +70,5 @@ extern "C" {
     /// enhancement with undefined behavior on a mismatch. Instead, this hardened
     /// allocator implementation uses it to improve security by checking that the
     /// passed size matches the allocated size.
-    pub fn h_free_sized(ptr: *mut c_void, expected_size: usize) -> c_void;
+    pub fn free_sized(ptr: *mut c_void, expected_size: usize) -> c_void;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,77 +1,31 @@
 #![no_std]
 
-use core::ffi::{c_int, c_void};
+mod bindings;
+pub use bindings::*;
+use core::alloc::{GlobalAlloc, Layout};
+use core::ffi::c_void;
+use ffi::*;
 
-extern crate libc;
+pub struct HardenedMalloc;
 
-extern "C" {
-    /*
-        TODO: implement this
+unsafe impl GlobalAlloc for HardenedMalloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        h_malloc(layout.size()) as *mut u8
+    }
 
-        #ifdef __ANDROID__
-    #define H_MALLOC_USABLE_SIZE_CONST const
-    #else
-    #define H_MALLOC_USABLE_SIZE_CONST
-    #endif
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        h_calloc(layout.size(), 1) as *mut u8
+    }
 
-        for:
-        // glibc extensions
-    size_t h_malloc_usable_size(H_MALLOC_USABLE_SIZE_CONST void *ptr);
-     */
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        h_free(ptr as *mut c_void);
+    }
 
-    /* C standard */
-
-    pub fn h_malloc(size: usize) -> *mut c_void;
-    pub fn h_calloc(nmemb: usize, size: usize) -> *mut c_void;
-    pub fn h_realloc(ptr: *mut c_void, size: usize) -> *mut c_void;
-    pub fn h_aligned_malloc(alignment: usize, size: usize) -> *mut c_void;
-    pub fn h_free(ptr: *mut c_void);
-
-    /* POSIX */
-
-    pub fn h_posix_memalign(memptr: *mut *mut c_void, alignment: usize, size: usize) -> c_int;
-
-    /* glibc extensions */
-
-    pub fn h_malloc_usable_size(ptr: *const c_void) -> usize;
-    pub fn h_mallopt(param: c_int, value: c_int) -> c_int;
-    pub fn h_malloc_trim(pad: usize) -> c_int;
-    pub fn h_malloc_stats(void: c_void) -> c_void;
-
-    /* obsolete glibc extensions */
-
-    pub fn h_memalign(alignment: usize, size: usize) -> *mut c_void;
-    pub fn h_pvalloc(size: usize) -> *mut c_void;
-    pub fn h_cfree(ptr: *mut c_void) -> c_void;
-    pub fn h_malloc_get_state(void: c_void) -> c_void;
-    pub fn h_malloc_set_state(ptr: *mut c_void) -> c_int;
-
-    /*TODO: implement this see the top:
-        #if defined(__GLIBC__) || defined(__ANDROID__)
-    struct mallinfo h_mallinfo(void);
-    #endif
-    #ifndef __ANDROID__
-    int h_malloc_info(int options, FILE *fp);
-    #endif
-     */
-
-    /* hardened_malloc extensions */
-
-    /// return an upper bound on object size for any pointer based on malloc metadata
-    pub fn h_malloc_object_size(ptr: *const c_void) -> usize;
-
-    /// similar to malloc_object_size, but avoids locking so the results are much more limited
-    pub fn h_malloc_object_size_fast(ptr: *const c_void) -> usize;
-
-    /// The free function with an extra parameter for passing the size requested at
-    /// allocation time.
-    ///
-    /// This offers the same functionality as C++14 sized deallocation and can be
-    /// used to implement it.
-    ///
-    /// A performance-oriented allocator would use this as a performance
-    /// enhancement with undefined behavior on a mismatch. Instead, this hardened
-    /// allocator implementation uses it to improve security by checking that the
-    /// passed size matches the allocated size.
-    pub fn h_free_sized(ptr: *mut c_void, expected_size: usize) -> c_void;
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, size: usize) -> *mut u8 {
+        h_realloc(ptr as *mut c_void, size) as *mut u8
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,27 @@
 #![no_std]
 
 mod bindings;
-pub use bindings::*;
+pub use bindings::{malloc, calloc, free, realloc};
 use core::alloc::{GlobalAlloc, Layout};
 use core::ffi::c_void;
-use ffi::*;
 
 pub struct HardenedMalloc;
 
 unsafe impl GlobalAlloc for HardenedMalloc {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        h_malloc(layout.size()) as *mut u8
+        malloc(layout.size()) as *mut u8
     }
-
     #[inline]
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        h_calloc(layout.size(), 1) as *mut u8
+        calloc(layout.size(), 1) as *mut u8
     }
-
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        h_free(ptr as *mut c_void);
+       free(ptr as *mut c_void);
     }
-
     #[inline]
     unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, size: usize) -> *mut u8 {
-        h_realloc(ptr as *mut c_void, size) as *mut u8
+       realloc(ptr as *mut c_void, size) as *mut u8
     }
 }


### PR DESCRIPTION
Hardened malloc has several preprocessor definitions which prevent the actual symbols (h_malloc) from appearing in the binary, replacing them with their C counterparts.